### PR TITLE
Report error for older versions of node

### DIFF
--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -13,6 +13,10 @@ module.exports = function (grunt) {
 
   grunt.registerMultiTask('validate_html', 'W3C nu html validation', function() {
 
+    if (spawn === undefined) {
+      grunt.warn('Cannot find child_process.spawnSync - Update node.js');
+    }
+
     var options = this.options({
       customtags: [],
       customattrs: [],


### PR DESCRIPTION
Older versions didn't include child_process.spawnSync.
